### PR TITLE
Fix buffer is not defined typo

### DIFF
--- a/lib/ble-manager.js
+++ b/lib/ble-manager.js
@@ -773,7 +773,7 @@ function BleManager(transport, staticRandomAddress, initCallback) {
 				function parseBdAddr(pos) {
 					var str = '';
 					for (var i = 5; i >= 0; i--) {
-						str += (0x100 + buffer[pos + i]).toString(16).substr(-2).toUpperCase();
+						str += (0x100 + buf[pos + i]).toString(16).substr(-2).toUpperCase();
 						if (i != 0) {
 							str += ':';
 						}


### PR DESCRIPTION
Firstly, this package has been a godsend, thank you @Emill it has been multitudes more reliable than any other Node JS BLE library I could find and is meticulously documented 🙌.

Have had `"ReferenceError: buffer is not defined at parseBdAddr"` crop up from time to time in our Sentry logs which appears to track back to this little typo. Hard to reproduce as I believe parseBdAddr is only being called in very special edge cases where there is one of the following types of data within an advertisement:
```typescript
case 0x17: // Public Target Address
case 0x18: // Random Target Address
```