### PR TITLE
Add txCidToRxCid mapping during connect response

### DIFF
--- a/lib/ble-manager.js
+++ b/lib/ble-manager.js
@@ -1654,7 +1654,7 @@ function BleManager(transport, staticRandomAddress, initCallback) {
 						obj.txCredits = responseData.readUInt16LE(6);
 						obj.isActive = true;
 						obj.userObj = new L2CAPCoC(obj);
-						
+						txCidToRxCid[obj.txCid] = rxCid; // Required for Credits Receiving on client side.
 						callback(result, obj.userObj);
 					}, function() {
 						fail(L2CAPCoCErrors.TIMEOUT);


### PR DESCRIPTION
This is required for the credit receiving functionality, so that the client can derive the obj to use the credits on.